### PR TITLE
feat: add Poetry tab with multilingual poetry generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,12 +132,13 @@
                 <div id="reflection-prompt-display-day" class="mt-4 text-center italic"></div>
             </section>
             <section class="mt-6">
-                <div class="grid grid-cols-5 gap-2">
+                <div class="grid grid-cols-6 gap-2">
                     <div id="geopolitics-clickable" class="preview-card"><h3 class="font-bold text-sm">World Order</h3></div>
                     <div id="tennis-clickable" class="preview-card"><h3 class="font-bold text-sm">Tennis</h3></div>
                     <div id="coffee-clickable" class="preview-card"><h3 class="font-bold text-sm">Coffee</h3></div>
                     <div id="guitar-clickable" class="preview-card"><h3 class="font-bold text-sm">Guitar</h3></div>
                     <div id="history-clickable" class="preview-card"><h3 class="font-bold text-sm">History</h3></div>
+                    <div id="poetry-clickable" class="preview-card"><h3 class="font-bold text-sm">Poetry</h3></div>
                 </div>
             </section>
             <section class="mt-6">
@@ -165,12 +166,13 @@
                 <div id="tasks-list-crossover" class="mt-4"></div>
             </section>
             <section class="mt-6">
-                <div class="grid grid-cols-5 gap-2">
+                <div class="grid grid-cols-6 gap-2">
                     <div id="geopolitics-clickable-crossover" class="preview-card"><h3 class="font-bold text-sm">World Order</h3></div>
                     <div id="tennis-clickable-crossover" class="preview-card"><h3 class="font-bold text-sm">Tennis</h3></div>
                     <div id="coffee-clickable-crossover" class="preview-card"><h3 class="font-bold text-sm">Coffee</h3></div>
                     <div id="guitar-clickable-crossover" class="preview-card"><h3 class="font-bold text-sm">Guitar</h3></div>
                     <div id="history-clickable-crossover" class="preview-card"><h3 class="font-bold text-sm">History</h3></div>
+                    <div id="poetry-clickable-crossover" class="preview-card"><h3 class="font-bold text-sm">Poetry</h3></div>
                 </div>
             </section>
             <section class="mt-6">
@@ -193,12 +195,13 @@
                 <div id="hood-preview-clickable-night" class="preview-card mt-4 cursor-pointer"><h3 class="font-bold">Under the Hood</h3></div>
             </section>
             <section class="mt-6">
-                <div class="grid grid-cols-5 gap-2">
+                <div class="grid grid-cols-6 gap-2">
                     <div id="geopolitics-clickable-night" class="preview-card"><h3 class="font-bold text-sm">World Order</h3></div>
                     <div id="tennis-clickable-night" class="preview-card"><h3 class="font-bold text-sm">Tennis</h3></div>
                     <div id="coffee-clickable-night" class="preview-card"><h3 class="font-bold text-sm">Coffee</h3></div>
                     <div id="guitar-clickable-night" class="preview-card"><h3 class="font-bold text-sm">Guitar</h3></div>
                     <div id="history-clickable-night" class="preview-card"><h3 class="font-bold text-sm">History</h3></div>
+                    <div id="poetry-clickable-night" class="preview-card"><h3 class="font-bold text-sm">Poetry</h3></div>
                 </div>
             </section>
              <section class="mt-6">
@@ -311,6 +314,19 @@
                     <button class="modal-close-btn text-3xl leading-none font-bold hover:text-black">&times;</button>
                 </div>
                 <div id="history-content" class="overflow-y-auto">
+                    <!-- JS will populate this -->
+                </div>
+                 <div class="text-center mt-4 pt-2 border-t"><button class="chat-context-btn footer-btn">Chat about this</button></div>
+            </div>
+        </div>
+
+        <div id="poetry-modal" class="fixed inset-0 bg-black bg-opacity-50 hidden justify-center items-center p-4 z-50">
+            <div class="modal-content-panel p-4 rounded-lg max-w-2xl w-full mx-auto max-h-[90vh] flex flex-col">
+                <div class="flex justify-between items-center mb-3">
+                    <h3 class="text-lg font-bold">Daily Poetry</h3>
+                    <button class="modal-close-btn text-3xl leading-none font-bold hover:text-black">&times;</button>
+                </div>
+                <div id="poetry-content" class="overflow-y-auto">
                     <!-- JS will populate this -->
                 </div>
                  <div class="text-center mt-4 pt-2 border-t"><button class="chat-context-btn footer-btn">Chat about this</button></div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1062,6 +1062,90 @@ Format the response as JSON with these exact fields:
         }
     }
 
+    async function fetchAndShowPoetry() {
+        const modal = document.getElementById('poetry-modal');
+        const contentEl = document.getElementById('poetry-content');
+        if (!modal || !contentEl) return;
+
+        modal.classList.remove('hidden');
+        modal.classList.add('flex');
+        contentEl.innerHTML = '<p>Generating beautiful poetry for you...</p>';
+
+        try {
+            const dayOfYear = getDayOfYear(activeContentDate);
+            const prompt = `For day ${dayOfYear} of the year, generate a beautiful 2-line poem in English, Hindi, Urdu, or Punjabi. The poem should be meaningful and inspiring. Also provide a simple explanation of what the poet is trying to convey in simple words. Format your response as:
+            
+Poem:
+[2 lines of poetry]
+
+Language: [English/Hindi/Urdu/Punjabi]
+
+Explanation:
+[Simple explanation of the poem's meaning and what the poet is trying to convey]`;
+            
+            const response = await ai.models.generateContent({
+                model: 'gemini-2.5-flash',
+                contents: prompt,
+                config: {
+                    responseMimeType: 'application/json',
+                    responseSchema: {
+                        type: Type.OBJECT,
+                        properties: {
+                            poem: { 
+                                type: Type.STRING, 
+                                description: 'The 2-line poem in the specified language.' 
+                            },
+                            language: {
+                                type: Type.STRING,
+                                description: 'The language of the poem (English, Hindi, Urdu, or Punjabi).'
+                            },
+                            explanation: {
+                                type: Type.STRING,
+                                description: 'A simple explanation of what the poet is trying to convey.'
+                            }
+                        },
+                        required: ["poem", "language", "explanation"]
+                    }
+                }
+            });
+
+            let html = '';
+
+            if (response.text) {
+                try {
+                    const data = JSON.parse(response.text);
+                    html += `<div class="mb-6">`;
+                    html += `<h4 class="text-lg font-bold mb-3 text-center">Daily Poetry</h4>`;
+                    html += `<div class="bg-gray-50 p-4 rounded-lg mb-4">`;
+                    html += `<p class="text-lg italic text-center leading-relaxed">${escapeHtml(data.poem)}</p>`;
+                    html += `<p class="text-sm text-gray-600 text-center mt-2">Language: ${escapeHtml(data.language)}</p>`;
+                    html += `</div>`;
+                    html += `<div class="bg-blue-50 p-4 rounded-lg">`;
+                    html += `<h5 class="font-bold mb-2">What the poet is saying:</h5>`;
+                    html += `<p class="text-sm leading-relaxed">${escapeHtml(data.explanation)}</p>`;
+                    html += `</div>`;
+                    html += `</div>`;
+                } catch (parseError) {
+                    // Fallback if JSON parsing fails
+                    html += `<div class="mb-6">`;
+                    html += `<h4 class="text-lg font-bold mb-3 text-center">Daily Poetry</h4>`;
+                    html += `<div class="bg-gray-50 p-4 rounded-lg">`;
+                    html += `<p class="text-lg italic text-center leading-relaxed">${escapeHtml(response.text)}</p>`;
+                    html += `</div>`;
+                    html += `</div>`;
+                }
+            } else {
+                html += `<p>Could not generate poetry at this time.</p>`;
+            }
+
+            contentEl.innerHTML = html;
+
+        } catch (error) {
+            console.error("Error fetching Poetry:", error);
+            contentEl.innerHTML = '<p>An API Error occurred. Could not generate poetry at this time.</p>';
+        }
+    }
+
     // --- GEMINI API LOGIC ---
     async function getReflectionPrompt(pointer: string) {
         const reflectionPromptDisplay = document.getElementById('reflection-prompt-display-day');
@@ -1569,18 +1653,20 @@ Format the response as JSON with these exact fields:
             if (target.closest('#analytics-preview-clickable-crossover') || target.closest('#analytics-preview-clickable-night')) return showAnalyticsModal('tomorrow');
             if (target.closest('#hood-preview-clickable-crossover') || target.closest('#hood-preview-clickable-night')) return showHoodModal('tomorrow');
 
-            if (target.closest('#geopolitics-clickable')) return fetchAndShowWorldOrder();
-            if (target.closest('#tennis-clickable')) return fetchAndShowTennisMatches();
-            if (target.closest('#coffee-clickable')) return fetchAndShowCoffeeTip();
-            if (target.closest('#guitar-clickable')) return fetchAndShowGuitarTab();
-            if (target.closest('#history-clickable')) return fetchAndShowHistory();
+                    if (target.closest('#geopolitics-clickable')) return fetchAndShowWorldOrder();
+        if (target.closest('#tennis-clickable')) return fetchAndShowTennisMatches();
+        if (target.closest('#coffee-clickable')) return fetchAndShowCoffeeTip();
+        if (target.closest('#guitar-clickable')) return fetchAndShowGuitarTab();
+        if (target.closest('#history-clickable')) return fetchAndShowHistory();
+        if (target.closest('#poetry-clickable')) return fetchAndShowPoetry();
 
             // Crossover and Night module tab event listeners
-            if (target.closest('#geopolitics-clickable-crossover') || target.closest('#geopolitics-clickable-night')) return fetchAndShowWorldOrder();
-            if (target.closest('#tennis-clickable-crossover') || target.closest('#tennis-clickable-night')) return fetchAndShowTennisMatches();
-            if (target.closest('#coffee-clickable-crossover') || target.closest('#coffee-clickable-night')) return fetchAndShowCoffeeTip();
-            if (target.closest('#guitar-clickable-crossover') || target.closest('#guitar-clickable-night')) return fetchAndShowGuitarTab();
-            if (target.closest('#history-clickable-crossover') || target.closest('#history-clickable-night')) return fetchAndShowHistory();
+                    if (target.closest('#geopolitics-clickable-crossover') || target.closest('#geopolitics-clickable-night')) return fetchAndShowWorldOrder();
+        if (target.closest('#tennis-clickable-crossover') || target.closest('#tennis-clickable-night')) return fetchAndShowTennisMatches();
+        if (target.closest('#coffee-clickable-crossover') || target.closest('#coffee-clickable-night')) return fetchAndShowCoffeeTip();
+        if (target.closest('#guitar-clickable-crossover') || target.closest('#guitar-clickable-night')) return fetchAndShowGuitarTab();
+        if (target.closest('#history-clickable-crossover') || target.closest('#history-clickable-night')) return fetchAndShowHistory();
+        if (target.closest('#poetry-clickable-crossover') || target.closest('#poetry-clickable-night')) return fetchAndShowPoetry();
 
 
             const archiveModal = document.getElementById('archive-modal');


### PR DESCRIPTION
## What this PR does
- Adds a new "Poetry" tab to Day, Crossover, and Night modules
- Generates 2-line poems in English, Hindi, Urdu, or Punjabi
- Provides simple explanations of poetic meaning
- Uses Google GenAI for content generation

## Changes Made
- Modified `index.html` to add Poetry tab to all modules
- Added `fetchAndShowPoetry()` function in `src/index.tsx`
- Integrated event listeners for Poetry tab clicks
- Added Poetry modal structure with content display

## Testing
- ✅ Local build successful (`npm run build`)
- ✅ TypeScript compilation passed (`npm run type-check`)
- ✅ Feature tested locally

## Screenshots
[Will add after testing on Vercel]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a "Daily Poetry" preview card in the Reflect, Today's State, and Tomorrow's Preview sections.
  * Added a modal dialog that displays a daily 2-line poem in English, Hindi, Urdu, or Punjabi, along with an explanation and a chat option.
  * Users can access the poetry feature from any of the three sections.

* **Style**
  * Updated grid layouts in the preview sections to accommodate the new poetry card.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->