### PR TITLE
feat: change timezone from Pacific to Eastern Time for Montreal - Upd…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // --- UTILITY FUNCTIONS ---
     function getCanonicalTime() {
-        const canonicalTimeZone = 'America/Los_Angeles';
+        const canonicalTimeZone = 'America/New_York';
         
         const formatter = new Intl.DateTimeFormat('en-US', {
             year: 'numeric',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,12 +32,12 @@ document.addEventListener('DOMContentLoaded', () => {
     let testTimeOverride: Date | null = null;
 
     /**
-     * Gets the current date and hour based on a canonical timezone ('America/Los_Angeles')
+     * Gets the current date and hour based on a canonical timezone ('America/New_York')
      * to ensure the app's state is consistent for all users, regardless of their location.
      * @returns An object with the canonical Date object and the hour (0-23).
      */
     function getCanonicalTime(): { now: Date, hour: number } {
-        const canonicalTimeZone = 'America/Los_Angeles';
+        const canonicalTimeZone = 'America/New_York';
         
         // Use test override if set (for time zone testing)
         const baseDate = testTimeOverride || new Date();
@@ -92,22 +92,22 @@ document.addEventListener('DOMContentLoaded', () => {
     (window as any).testTimeZone = {
         // Test CrossOver Module (5 PM - 6 PM)
         testCrossOver: () => {
-            testTimeOverride = new Date('2024-01-15T17:30:00.000-08:00');
-            console.log('🧪 Testing CrossOver Module (5:30 PM)');
+            testTimeOverride = new Date('2024-01-15T17:30:00.000-05:00'); // EST
+            console.log('🧪 Testing CrossOver Module (5:30 PM Eastern Time)');
             location.reload();
         },
         
         // Test Night Module (6 PM - 8 AM)
         testNight: () => {
-            testTimeOverride = new Date('2024-01-15T19:00:00.000-08:00');
-            console.log('🧪 Testing Night Module (7:00 PM)');
+            testTimeOverride = new Date('2024-01-15T19:00:00.000-05:00'); // EST
+            console.log('🧪 Testing Night Module (7:00 PM Eastern Time)');
             location.reload();
         },
         
         // Test Day Module (8 AM - 5 PM)
         testDay: () => {
-            testTimeOverride = new Date('2024-01-15T10:00:00.000-08:00');
-            console.log('🧪 Testing Day Module (10:00 AM)');
+            testTimeOverride = new Date('2024-01-15T10:00:00.000-05:00'); // EST
+            console.log('🧪 Testing Day Module (10:00 AM Eastern Time)');
             location.reload();
         },
         


### PR DESCRIPTION
## 🕐 Timezone Change for Montreal

### Changes Made
- ✅ Updated canonical timezone from `'America/Los_Angeles'` to `'America/New_York'`
- ✅ Updated test utilities to use Eastern Time offsets (`-05:00`)
- ✅ Updated console log messages to specify "Eastern Time"
- ✅ Maintained same module schedules (8AM-5PM Day, 5PM-6PM Crossover, 6PM-8AM Night)

### Files Modified
- `src/index.tsx` - Updated timezone and test utilities
- `src/index.js` - Updated timezone

### Testing Performed
- ✅ Local development server tested
- ✅ Timezone utilities tested via browser console:
  - `testTimeZone.testDay()` - 10:00 AM Eastern Time
  - `testTimeZone.testCrossOver()` - 5:30 PM Eastern Time  
  - `testTimeZone.testNight()` - 7:00 PM Eastern Time

### Benefits
- 🎯 Correct timezone for Montreal user (EST/EDT with automatic DST handling)
- 🧪 Updated test utilities for accurate Eastern Time testing
- 📝 Clear documentation of changes

### Module Schedules (Unchanged)
- **DAY:** 8:00 AM - 5:00 PM Eastern Time
- **CROSSOVER:** 5:00 PM - 6:00 PM Eastern Time  
- **NIGHT:** 6:00 PM - 8:00 AM Eastern Time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application's canonical time zone from Pacific Time to Eastern Time for all time-related calculations and displays.
  * Adjusted test time overrides and console log messages to reference Eastern Time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->