### PR TITLE
feat(guitar): Guitar tab modal with Key + Tuning, classic rock pick, lesson links

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -967,26 +967,51 @@ Use actual current tournament data and highlight Canadian players with <strong> 
 
         modal.classList.remove('hidden');
         modal.classList.add('flex');
-        contentEl.innerHTML = '<p>Loading today\'s guitar lesson...</p>';
+        contentEl.innerHTML = `<p>Loading today&apos;s guitar pick...</p>`;
 
-        let guitarData;
+        let data: {
+            title: string;
+            artist: string;
+            key: string;
+            tuning: string;
+            lyricsWithChords: string;
+            lyricsPlain: string;
+            chordChanges: string;
+            inspiration: string;
+            youtubeLessonTitle: string;
+            youtubeLessonUrl: string;
+            spotifyUrl: string;
+            wordChordMap: Array<{ wordIndex: number; word: string; chord: string }>;
+        } | null = null;
+
         try {
-            // Use a unique prompt for each day to get a different lesson
             const dayOfYear = getDayOfYear(activeContentDate);
-            const prompt = `For day ${dayOfYear} of the year, generate a unique, self-contained guitar lesson for someone learning to play guitar. Include:
-1. A song title and artist (choose a popular, beginner-friendly song)
-2. A simple guitar tab in ASCII format (use - for strings, numbers for frets, keep it simple)
-3. A brief lesson explaining the technique or chord progression
-4. A practice tip for beginners
+            const prompt = `Give me a Random Classic Rock song that I can learn to play on Guitar for day ${dayOfYear} of the year. Return JSON ONLY with these exact fields:
 
-Format the response as JSON with these exact fields:
 {
-    "title": "Song Name - Artist",
-    "tab": "E|---0---0---0---0---\\nB|---1---1---1---1---\\nG|---0---0---0---0---\\nD|---2---2---2---2---\\nA|---3---3---3---3---\\nE|---x---x---x---x---",
-    "lesson": "This lesson focuses on basic strumming pattern...",
-    "tip": "Practice slowly and focus on clean chord transitions"
-}`;
-            
+  "title": "Song title only",
+  "artist": "Artist name",
+  "key": "Musical key (e.g., A minor, E major)",
+  "tuning": "Guitar tuning (e.g., Standard E A D G B E, Drop D, Eb Standard, DADGAD)",
+  "lyricsWithChords": "Multi-line text with chords inline or above lyrics. Keep it short (intro/verse/chorus). Use plain ASCII.",
+  "lyricsPlain": "Same excerpt as above but with just the lyrics words separated by spaces; no chords, no tabs, no punctuation-heavy markup.",
+  "chordChanges": "Concise chord progression overview (e.g., Verse: G-D-Em-C | Chorus: C-G-Am-F)",
+  "inspiration": "Song facts about what inspired the song. Make me fall in love with it.",
+  "youtubeLessonTitle": "Best YouTube video title for a guitar lesson on this song",
+  "youtubeLessonUrl": "Direct YouTube URL starting with https://",
+  "spotifyUrl": "Direct Spotify track URL starting with https://open.spotify.com/",
+  "wordChordMap": [
+    { "wordIndex": 1, "word": "When", "chord": "G" },
+    { "wordIndex": 3, "word": "the", "chord": "D" }
+  ]
+}
+
+Rules:
+- Keep lyrics snippet short and fair-use; do not include full lyrics.
+- Use a well-known Classic Rock song with beginner-friendly parts.
+- Ensure URLs are valid-looking and direct. No markdown, no extra commentary.
+- wordChordMap should include ONLY the words at which a new chord STARTS. Index is 1-based on lyricsPlain tokenization by spaces.`;
+
             const response = await ai.models.generateContent({
                 model: 'gemini-2.5-flash',
                 contents: prompt,
@@ -995,58 +1020,109 @@ Format the response as JSON with these exact fields:
                     responseSchema: {
                         type: Type.OBJECT,
                         properties: {
-                            title: { 
-                                type: Type.STRING, 
-                                description: 'The song title and artist.' 
+                            title: { type: Type.STRING },
+                            artist: { type: Type.STRING },
+                            key: { type: Type.STRING },
+                            tuning: { type: Type.STRING },
+                            lyricsWithChords: { type: Type.STRING },
+                            lyricsPlain: { type: Type.STRING },
+                            chordChanges: { type: Type.STRING },
+                            inspiration: { type: Type.STRING },
+                            youtubeLessonTitle: { type: Type.STRING },
+                            youtubeLessonUrl: { type: Type.STRING },
+                            spotifyUrl: { type: Type.STRING },
+                            wordChordMap: {
+                                type: Type.ARRAY,
+                                items: {
+                                    type: Type.OBJECT,
+                                    properties: {
+                                        wordIndex: { type: Type.NUMBER },
+                                        word: { type: Type.STRING },
+                                        chord: { type: Type.STRING },
+                                    },
+                                    required: ['wordIndex', 'word', 'chord'],
+                                },
                             },
-                            tab: {
-                                type: Type.STRING,
-                                description: 'The guitar tab in ASCII format.'
-                            },
-                            lesson: {
-                                type: Type.STRING,
-                                description: 'A brief lesson explaining the technique.'
-                            },
-                            tip: {
-                                type: Type.STRING,
-                                description: 'A practice tip for beginners.'
-                            }
                         },
-                        required: ["title", "tab", "lesson", "tip"]
-                    }
-                }
+                        required: [
+                            'title',
+                            'artist',
+                            'key',
+                            'tuning',
+                            'lyricsWithChords',
+                            'lyricsPlain',
+                            'chordChanges',
+                            'inspiration',
+                            'youtubeLessonTitle',
+                            'youtubeLessonUrl',
+                            'spotifyUrl',
+                            'wordChordMap',
+                        ],
+                    },
+                },
             });
 
             try {
-                guitarData = JSON.parse(response.text);
+                data = JSON.parse(response.text);
             } catch (jsonError) {
-                 console.error("Failed to parse JSON from Gemini response for guitar lesson:", jsonError);
-                 contentEl.innerHTML = `<p>Could not parse the lesson. Please try again later.</p>`;
-                 return;
+                console.error('Failed to parse JSON for guitar feature:', jsonError);
+                contentEl.innerHTML = `<p>Could not parse the guitar pick. Please try again later.</p>`;
+                return;
             }
-
         } catch (error) {
-            console.error("Error fetching Guitar Lesson:", error);
-            contentEl.innerHTML = '<p>Could not retrieve a guitar lesson at this time.</p>';
+            console.error('Error fetching Guitar feature:', error);
+            contentEl.innerHTML = `<p>Could not retrieve a guitar pick at this time.</p>`;
             return;
         }
-        
-        if (guitarData && guitarData.title && guitarData.tab && guitarData.lesson && guitarData.tip) {
-             contentEl.innerHTML = `
-                <div class="space-y-4">
-                    <h4 class="font-bold text-md mb-2">${guitarData.title.replace(/\*/g, '')}</h4>
-                    <div class="bg-gray-100 p-3 rounded font-mono text-sm overflow-x-auto">
-                        <pre>${guitarData.tab.replace(/\*/g, '')}</pre>
-                    </div>
-                    <p class="text-base mb-4">${guitarData.lesson.replace(/\*/g, '')}</p>
-                    <div class="bg-blue-50 p-3 rounded">
-                        <p class="text-sm italic">💡 ${guitarData.tip.replace(/\*/g, '')}</p>
-                    </div>
-                </div>
-            `;
-        } else {
-             contentEl.innerHTML = '<p>Could not retrieve a guitar lesson. The response was empty.</p>';
+
+        if (!data) {
+            contentEl.innerHTML = `<p>No data returned for this guitar pick.</p>`;
+            return;
         }
+
+        const safe = (s: string) => escapeHtml((s || '').replace(/\*/g, ''));
+
+        contentEl.innerHTML = `
+        <div class="space-y-4">
+            <h4 class="font-bold text-md">${safe(data.title)} — ${safe(data.artist)}</h4>
+
+            <div class="text-sm">
+                <p><span class="font-semibold">Key:</span> ${safe(data.key)}</p>
+                <p><span class="font-semibold">Tuning:</span> ${safe(data.tuning)}</p>
+            </div>
+
+            <div class="bg-gray-100 p-3 rounded font-mono text-sm overflow-x-auto">
+                <p class="font-semibold mb-1">Lyrics & Chords (excerpt)</p>
+                <pre>${safe(data.lyricsWithChords)}</pre>
+            </div>
+
+            
+
+            <div class="bg-blue-50 p-3 rounded text-sm">
+                <p class="font-semibold mb-1">Chord Changes</p>
+                <p>${safe(data.chordChanges)}</p>
+            </div>
+
+            <div class="text-sm">
+                <p class="font-semibold mb-1">Why this song rocks</p>
+                <p>${safe(data.inspiration)}</p>
+            </div>
+
+            <div class="text-sm">
+                <p class="font-semibold mb-1">Best YouTube Lesson</p>
+                <a href="${safe(data.youtubeLessonUrl)}" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline">
+                    ${safe(data.youtubeLessonTitle)}
+                </a>
+            </div>
+
+            <div class="text-sm">
+                <p class="font-semibold mb-1">Listen on Spotify</p>
+                <a href="${safe(data.spotifyUrl)}" target="_blank" rel="noopener noreferrer" class="text-green-700 underline">
+                    ${safe(data.spotifyUrl)}
+                </a>
+            </div>
+        </div>
+        `;
     }
 
     async function fetchAndShowHistory() {


### PR DESCRIPTION
This PR adds the enhanced Guitar feature:\n\n- Random classic rock pick with key, tuning, lyrics+chords excerpt, chord changes\n- Inspiration facts, best YouTube lesson link, and Spotify link\n- Simplified UI (removed per-word chord map)\n- Strict JSON schema for reliable parsing; safe rendering\n\nTest: Click the Guitar tab in the Day module.\n\nCloses: n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a comprehensive "guitar pick" feature, offering detailed information about a random classic rock song suitable for guitar learners, including song metadata, lyrics with chords, chord changes, inspiration, and external links to YouTube and Spotify.

* **Improvements**
  * Enhanced the user interface to display richer and more structured guitar learning content.
  * Updated loading and error messages to reflect the new "guitar pick" terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->